### PR TITLE
fix(utils): update themeFromHues function to specify it's a themer theme

### DIFF
--- a/apps/v1/utils/themeFromHues.ts
+++ b/apps/v1/utils/themeFromHues.ts
@@ -72,7 +72,9 @@ export function themeFromHues({
   rgbToHex,
   rgba,
   createColorTheme,
-}: Options): StudioTheme {
+}: Options): StudioTheme & {
+  __themer: true
+} {
   function multiply(bg: string, fg: string): string {
     const b = parseColor(bg)
     const s = parseColor(fg)
@@ -730,5 +732,5 @@ export function themeFromHues({
     },
   })
 
-  return { ...studioTheme, color }
+  return { ...studioTheme, color, __themer: true }
 }


### PR DESCRIPTION
Includes a `__themer: true` key into the themer generated theme to help detect from the studio when a theme is coming from themer. 

Given themer is using sanity ui 1.X the fonts theme has some differences that we need to reconciliate in the studio before adding it into the theme provider